### PR TITLE
FreeBSD: A realistic comment about CDE

### DIFF
--- a/FreeBSD/desktop-installer
+++ b/FreeBSD/desktop-installer
@@ -2688,7 +2688,7 @@ while [ $valid_selection = 0 ]; do
     printf "\n"
     line
     printf "1.. No desktop software (I'll install my own later)\n"
-    printf "2.. CDE (For nostalgia only, not fully functional or secure)\n"
+    printf "2.. CDE (Retro 1990's)\n"
     printf "3.. Cinnamon Desktop (Gnome 3 derivative)\n"
     printf "4.. Fluxbox Lightweight Window Manager\n"
     printf "5.. Gnome Desktop (Feature-rich and resource-intensive)\n"


### PR DESCRIPTION
CDE is certainly more secure than it was in the 1990's. Additionally, calendar and tooltalk database server are not enabled by default, not needed, nor should they be enabled, unless one wants to use the CDE supplied calendar or CDE supplied database. CDE will function without either enabled.