### PR TITLE
Near finishing OpenBSD support, testing needed/wanted.

### DIFF
--- a/OpenBSD/XenoDM/GiveConsole
+++ b/OpenBSD/XenoDM/GiveConsole
@@ -1,0 +1,22 @@
+#!/bin/ksh
+
+# Set Prefix for commands used
+prefix="/usr/X11R6"
+exec_prefix="${prefix}"
+prefix="/usr/X11R6"
+exec_prefix="${prefix}"
+
+pkill wish8.6
+
+GROUP=`id -g $USER`
+
+# Pass Ownership to the user
+chown $USER:$GROUP /dev/console
+if [ -c /dev/dri/card0 ]; then
+    chown $USER:$GROUP /dev/dri/card0
+fi
+if [ -c /dev/dri/renderD128 ]; then
+    chown $USER:$GROUP /dev/dri/renderD128
+fi
+# Register Session to the user
+${exec_prefix}/bin/sessreg -a -l $DISPLAY -u none $USER

--- a/OpenBSD/XenoDM/Xsetup_0
+++ b/OpenBSD/XenoDM/Xsetup_0
@@ -32,5 +32,5 @@ left_edge=`xrandr --screen 0 | grep primary | awk '{ print $4 }' \
 
 x=$(( $left_edge + ($width - 150) / 2 ))
 y=$(( ($height - 10) / 2 + 120 ))
-/usr/local/sbin/xdmshutdown -geometry +$x+$y &
-echo $! > /var/run/xdmshutdown.pid
+/usr/local/sbin/xenodmshutdown -geometry +$x+$y &
+echo $! > /var/run/xenodmshutdown.pid

--- a/OpenBSD/XenoDM/xenodmshutdown
+++ b/OpenBSD/XenoDM/xenodmshutdown
@@ -8,7 +8,7 @@ proc shutdownf {} { exec /sbin/shutdown -p now 2>/dev/console >/dev/console }
 
 proc rebootf {} { exec /sbin/shutdown -r now 2>/dev/console >/dev/console }
 
-proc restartx {} { exec /usr/sbin/service xdm restart 2>/dev/console >/dev/console }
+proc restartx {} { exec /usr/sbin/rcctl restart xenodm 2>/dev/console >/dev/console }
 
 button .shutdown -text "Shutdown" -background gray -activebackground #664444 -width 15 -command shutdownf
 

--- a/OpenBSD/desktop-installer
+++ b/OpenBSD/desktop-installer
@@ -66,7 +66,7 @@ EOM
 printf "Update installed packages? [y]/n "
 read update
 if [ 0"$update" != 0n ]; then
-    auto-update-pkgsrc --defaults
+    pkg_add -u 
 fi
 
 # Should have been installed as a dep, but just in case
@@ -75,8 +75,8 @@ pkg_add dbus git gmake xz feh tk-8.6.13 consolekit2
 cat << EOM
 
 1.. FVWM (OpenBSD default)
-2.. Gnome
-3.. KDE
+2.. CWM (OpenBSD alternate)
+3.. Lumina
 4.. LXQT
 5.. MATE
 6.. XFCE
@@ -91,45 +91,43 @@ XSESSION=/etc/X11/xenodm/Xsession
 de='unknown'
 case $de_num in
 1)
-    for pkg in evince xscreensaver; do
-	pkg_add $pkg
-    done
-    rm $HOME/.xsession
+    pkg_add xscreensaver
+    create_xsession fvwm
     ;;
 
 2)
-    # Install separately so user sees error messages
-    for pkg in evince gnome; do
-	pkg_add $pkg
-    done
-    create_xsession gnome-session
+    pkg_add xscreensaver
+    create_xsession cwm
     ;;
 
 3)
     # Install separately so user sees error messages
-    pkg_add kde-plasma
-    create_xsession startplasma-x11
+    for pkg in evince--light lumina; do
+        pkg_add $pkg
+    done
+    create_xsession start-lumina-desktop
     ;;
+
 4)
     # Install separately so user sees error messages
-    for pkg in evince lxqt; do
-	pkg_add $pkg
+    for pkg in evince--light lxqt lxqt-extras; do
+        pkg_add $pkg
     done
     create_xsession startlxqt
     ;;
 
 5)
     # Install separately so user sees error messages
-    for pkg in evince mate; do
-	pkg_add $pkg
+    for pkg in evince--light mate mate-extras; do
+        pkg_add $pkg
     done
     create_xsession mate-session
     ;;
 
 6)
     # Install separately so user sees error messages
-    for pkg in evince xfce4; do
-	pkg_add $pkg
+    for pkg in evince--light xfce xfce-extras; do
+        pkg_add $pkg
     done
     create_xsession xfce4-session
     ;;
@@ -139,12 +137,13 @@ case $de_num in
     read package
     printf "Session command? (Use pkg_info -L to verify) "
     read session_cmd
-    
+
     for pkg in xscreensaver $package; do
 	pkg_add $pkg
     done
     create_xsession $session_cmd
-    ;;  
+    ;;
+
 *)
     printf "Invalid selection.\n"
     exit 1
@@ -161,7 +160,7 @@ auto-enable-service messagebus $0
 
 # Enhanced XDM with background and restart/shutdown/restart-x11 buttons
 auto-replace-file /usr/local/share/desktop-installer/XenoDM/Xsetup_0 /etc/X11/xenodm/Xsetup_0
-# ^ What we want auto-admin to do here.
+auto-replace-file /usr/local/share/desktop-installer/XenoDM/GiveConsole /etc/X11/xenodm/GiveConsole
 
 cat << EOM
 
@@ -177,7 +176,7 @@ if ! pgrep bin/xenodm; then
     printf "Enable XenoDM graphical login? [y]/n "
     read xenodm
     if [ 0"$xenodm" != 0n ]; then
-        auto-enable-service xenodm
+        auto-enable-service xenodm $0
     fi
 fi
 


### PR DESCRIPTION
Hello!

I got around to manually testing this, and discovered kde and gnome acting up, I opted to use simpler desktop environments instead.

you need https://github.com/outpaddling/auto-admin/pull/11 for this to work correctly,

I also added the `,-light` flavor for evince as we don't need literally everything.

I added the `-extra` packages for the various bigger DE's just for a more streamlined experience, as well as using `ck-launch-session` as needed when the `pkg-readme` for the DE said to.

Thoughts?

I want some testers if possible, cos I only got so much time in my day. In my brief testing, these all seem to work as expected. 

After a little testing, I'll make a port on https://github.com/jasperla/openbsd-wip.git & update the getting-started.md file to finalize #30