### PR TITLE
FreeBSD: use -U option to prevent pkg updating repository on every call

### DIFF
--- a/FreeBSD/desktop-installer
+++ b/FreeBSD/desktop-installer
@@ -71,7 +71,7 @@ EOM
 	    install=yes
 	fi
 	if [ $install = yes ]; then
-	    if ! auto-install-packages -l $pkg 2>&1 \
+	    if ! auto-install-packages -l $pkg -U 2>&1 \
 		| tee $LOG_DIR/auto-install-packages.log; then
 		printf "Install failed.\n"
 		exit $?


### PR DESCRIPTION
Add `-U` parameter to calls to `auto-install-packages`. They are not required since package repositories are already updated earlier in the process, through the call to `auto-pkg-latest`.

This PR requires PR https://github.com/outpaddling/auto-admin/pull/14 to be merged first.

Closes #45 