### PR TITLE
Make battery-shutdown.sh actually do its job

### DIFF
--- a/Scripts/battery-shutdown.sh
+++ b/Scripts/battery-shutdown.sh
@@ -53,7 +53,6 @@ for user in $display_users; do
 	su -l $user -c 'env DISPLAY=:0 xhost +local:root' > /dev/null || true
     fi
 done
-exit
 
 if [ $ac_power = 0 ]; then
     if [ $time -ge 0 ]; then


### PR DESCRIPTION
Looks like an `exit` snuck in with 1d27495, effectively rendering the script a noop. Have been bitten by this due to several sudden poweroffs with no warning. :)