### PR TITLE
OpenBSD: no longer hard-code a pkg_add'd version of tk, just pull the 8.6.x branch from mirrors

### DIFF
--- a/OpenBSD/XenoDM/xenodmshutdown
+++ b/OpenBSD/XenoDM/xenodmshutdown
@@ -1,7 +1,5 @@
 #!/usr/local/bin/wish8.6
 
-# FIXME: Can we get ride of the wish version above?
-
 # NT 20 October 2002 - adapted/copied from various similar
 # scripts dragged kicking and screaming from the bowels of the web:)
 # NT 27 January 2003 - added a reboot button

--- a/OpenBSD/desktop-installer
+++ b/OpenBSD/desktop-installer
@@ -70,7 +70,7 @@ if [ 0"$update" != 0n ]; then
 fi
 
 # Should have been installed as a dep, but just in case
-pkg_add dbus avahi git gmake xz feh tk-8.6.13 consolekit2
+pkg_add dbus avahi git gmake xz feh tk--%8.6 consolekit2
 
 cat << EOM
 


### PR DESCRIPTION
As [This commit says](https://github.com/outpaddling/desktop-installer/commit/a1e2af98b9c863451d040e5d63d6450aaf1417e3), we should avoid hard-coding a tk version.

Unfortunately, no solution like tk-wrapper exists in the OpenBSD ports tree as far as I can tell. This simple workaround can ensure tk version 8.6.x is installed. I noticed a regression when I was testing the port on a fresh install of OpenBSD 7.7, where the "x" was hardcoded. Luckily, the OpenBSD pkg tools have a mechanism to install specific major versions using the `--%version` syntax in the pkgname. This will probably work for now. This also removes the FIXME in `xenodmshutdown`.

We'll still need to hardcode the shebang in the `xenodmshutdown` script, until a proper `tk-wrapper` pops up in the ports tree.