### PR TITLE
OpenBSD: add lumina desktop

### DIFF
--- a/OpenBSD/desktop-installer
+++ b/OpenBSD/desktop-installer
@@ -156,7 +156,7 @@ lxqt_config()
 lumina_config()
 {
     # Install separately so user sees error messages
-    for pkg in lumina qterminal; do
+    for pkg in lumina qterminal qpdfview lximage-qt; do
         pkg_add $pkg
     done
     xenodm_config start-lumina-desktop
@@ -323,15 +323,16 @@ cat << EOM
 
 1.. FVWM (OpenBSD default)
 2.. CWM (OpenBSD alternate)
-3.. LXQT
-4.. Lumina
-5.. MATE
-6.. XFCE
-7.. KDE-Plasma
-8.. GNOME
+3.. GNOME
+4.. KDE-Plasma
+5.. LXQT
+6.. Lumina
+7.. MATE
+8.. XFCE
 9.. Custom
 
 EOM
+
 printf "Selection? "
 read de_num
 
@@ -345,27 +346,27 @@ case $de_num in
     ;;
 
 3)
-    lxqt_config
+    gnome_config
     ;;
 
 4)
-    lumina_config
+    kde_config
     ;;
 
 5)
-    mate_config
+    lxqt_config
     ;;
 
 6)
-    xfce_config
+    lumina_config
     ;;
 
 7)
-    kde_config
+    mate_config
     ;;
-    
+
 8)
-    gnome_config
+    xfce_config
     ;;
 
 9)

--- a/OpenBSD/desktop-installer
+++ b/OpenBSD/desktop-installer
@@ -129,6 +129,7 @@ EOM
 #   History:
 #   Date        Name         Modification
 #   2026-04-30  izzy Meyer   Initial revision
+#   2026-05-20  izzy Meyer   Add Lumina Desktop option
 ##########################################################################
 
 fvwm_config()
@@ -150,6 +151,15 @@ lxqt_config()
         pkg_add $pkg
     done
     xenodm_config startlxqt
+}
+
+lumina_config()
+{
+    # Install separately so user sees error messages
+    for pkg in lumina qterminal; do
+        pkg_add $pkg
+    done
+    xenodm_config start-lumina-desktop
 }
 
 mate_config()
@@ -314,11 +324,12 @@ cat << EOM
 1.. FVWM (OpenBSD default)
 2.. CWM (OpenBSD alternate)
 3.. LXQT
-4.. MATE
-5.. XFCE
-6.. KDE-Plasma
-7.. GNOME
-8.. Custom
+4.. Lumina
+5.. MATE
+6.. XFCE
+7.. KDE-Plasma
+8.. GNOME
+9.. Custom
 
 EOM
 printf "Selection? "
@@ -338,22 +349,26 @@ case $de_num in
     ;;
 
 4)
-    mate_config
+    lumina_config
     ;;
 
 5)
-    xfce_config
+    mate_config
     ;;
 
 6)
+    xfce_config
+    ;;
+
+7)
     kde_config
     ;;
     
-7)
+8)
     gnome_config
     ;;
 
-8)
+9)
     custom_session_config
     ;;
 

--- a/OpenBSD/desktop-installer
+++ b/OpenBSD/desktop-installer
@@ -147,7 +147,7 @@ cwm_config()
 lxqt_config()
 {
     # Install separately so user sees error messages
-    for pkg in evince--light lxqt lxqt-extras; do
+    for pkg in evince--light lxqt lxqt-extras galculator; do
         pkg_add $pkg
     done
     xenodm_config startlxqt
@@ -156,7 +156,7 @@ lxqt_config()
 lumina_config()
 {
     # Install separately so user sees error messages
-    for pkg in lumina qterminal qpdfview lximage-qt; do
+    for pkg in lumina qterminal qpdfview lximage-qt galculator; do
         pkg_add $pkg
     done
     xenodm_config start-lumina-desktop


### PR DESCRIPTION
... 

What title says.

-- 

Bit more context: I believe I initially removed Lumina from an earlier version of this script as lumina had strange defaults and didn't fit my idea of a desktop. I understand there's a fair bit of users, @outpaddling included, that would benefit from lumina support in this desktop script so I retract my personal bias here.

So, now that the script is more modular, I feel now is a good time to add back lumina support to the script. I'm doing this as a PR to encourage discussion from contributors and users.